### PR TITLE
fixed typo changing 'live' to 'like'

### DIFF
--- a/manuscript/markdown/References and Rebinding/recursion.md
+++ b/manuscript/markdown/References and Rebinding/recursion.md
@@ -28,7 +28,7 @@ You can alias a function value:
     divisibleByTwo(42)
       //=> true
       
-What happens when we redefine a recursive function live `even`? Does `dividibleByTwo` still work? Let's try aliasing it and reassigning it:
+What happens when we redefine a recursive function like `even`? Does `dividibleByTwo` still work? Let's try aliasing it and reassigning it:
 
     even = void 0;
     


### PR DESCRIPTION
This fixes a one letter/one word typo.
