### PR TITLE
Fix curryTwo example

### DIFF
--- a/manuscript/markdown/Instances and Classes/revisiting-partial.md
+++ b/manuscript/markdown/Instances and Classes/revisiting-partial.md
@@ -90,7 +90,7 @@ Here's a function that curries any function with two arguments:
     
     function add2 (a, b) { return a + b }
     
-    curryTwo(add)(5)(6)
+    curryTwo(add2)(5)(6)
       //=> 11
 
 And from there we can curry a function with three arguments:


### PR DESCRIPTION
Function curryTwo was meant to curry function add2 instead of add, which
has 3 parameters
