### PR TITLE
Slight miss in one of the code examples

### DIFF
--- a/manuscript/markdown/References and Rebinding/modules.md
+++ b/manuscript/markdown/References and Rebinding/modules.md
@@ -155,9 +155,9 @@ It looks like this:
       }
       
       // public methods
-      var drawLine = function (screen, leftPoint, rightPoint) { ... }
-      var drawRect = function (screen, topLeft, bottomRight) { ... }
-      var drawCircle = function (screen, center, radius) { ... }
+      function drawLine(screen, leftPoint, rightPoint) { ... }
+      function drawRect(screen, topLeft, bottomRight) { ... }
+      function drawCircle(screen, center, radius) { ... }
       
       // private helpers
       function bitBlt (screen, ...) { ... }


### PR DESCRIPTION
Because at the moment of return the draw\* variables are not yet assigned (they are defined, thanks to JS’ hoisting), the DrawModule comes out filled with `undefined`s.
