### PR TITLE
Fix error in "bound" recipe.

### DIFF
--- a/manuscript/markdown/Instances and Classes/recipes/bound.md
+++ b/manuscript/markdown/Instances and Classes/recipes/bound.md
@@ -56,7 +56,7 @@ Of course, these are unbound methods we're "getting" from each object. Here's a 
 
     var bound = variadic( function (messageName, args) {
       
-      if (args === []) {
+      if (args.length === 0) {
         return function (instance) {
           return instance[messageName].bind(instance)
         }


### PR DESCRIPTION
Noticed an error while reading the bound recipe -- almost nothing will `=== []`, so the first if block will never execute.  It's just an optimized general case, so the recipe still would have worked.