### PR TITLE
Correct syntax in `get` method of ModelMaker function

### DIFF
--- a/manuscript/markdown/Objects, Mutation, and State/composition-and-extension.md
+++ b/manuscript/markdown/Objects, Mutation, and State/composition-and-extension.md
@@ -57,7 +57,7 @@ Here's an abstract "model" that supports undo and redo composed from a pair of s
               return obj
             },
             get: function (key) {
-              return attributes(key)
+              return attributes[key]
             },
             has: function (key) {
               return attributes.hasOwnProperty(key)


### PR DESCRIPTION
References issue [#104](https://github.com/raganwald/javascript-allonge/issues/104)